### PR TITLE
[Sikkerhet] Oppdaterer med ny catalog-info.yaml og engelske filnavn

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/.sikkerhet/ @carsmie
+/.security/ @carsmie

--- a/.security/description.yaml
+++ b/.security/description.yaml
@@ -1,4 +1,3 @@
-version: 3.0
 organization: Land
 product: Tjenester
 repo_types: [Documentation]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -10,29 +10,3 @@ spec:
   lifecycle: "production"
   owner: "datadeling_og_distribusjon"
   system: "tjenester"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Group"
-metadata:
-  name: "security_champion_kartverket.vectortiles.sprites"
-  title: "Security Champion kartverket.vectortiles.sprites"
-spec:
-  type: "security_champion"
-  parent: "land_security_champions"
-  members:
-  - "carsmie"
-  children:
-  - "resource:kartverket.vectortiles.sprites"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Resource"
-metadata:
-  name: "kartverket.vectortiles.sprites"
-  links:
-  - url: "https://github.com/kartverket/kartverket.vectortiles.sprites"
-    title: "kartverket.vectortiles.sprites på GitHub"
-spec:
-  type: "repo"
-  owner: "security_champion_kartverket.vectortiles.sprites"
-  dependencyOf:
-  - "component:kartverket.vectortiles.sprites"


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage. Vi fjerner nå resource og sec. champ hierarkiet. Videre dropper vi å ha versionsnummer i description.yaml